### PR TITLE
Adding a Ping call to the session check loop

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,6 +65,7 @@ func (c *Client) check() {
 			for i := 0; i < len(c.cluster); i++ {
 				go func() {
 					s := c.fetch()
+					s.Ping()
 					if !s.Available() {
 						s.check()
 					}


### PR DESCRIPTION
This code fixes an issue were tcp keepalive does not keep a connection
open above the ELB timeout, and tcp connections are dropped. The next
request against that session will fail, mark the session as unavailable,
and the session will reconnect for the next request, however a number of
requests do fail in this time (equal to the pool size).

An alternaitve to this change would be to work some retry logic into the
request cycle of the package to retry should the session be discovered to
be unavailable when the request fails.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/riaken/riaken-core/3)

<!-- Reviewable:end -->
