### PR TITLE
goprotobuf has moved to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Not exactly straightforward because they require the use of the RPB structs.
 	// Make sure to require this
 	import (
 		"github.com/riaken/riaken-core/rpb"
-		"code.google.com/p/goprotobuf/proto"
+		"github.com/golang/protobuf/proto"
 	)
 
 	// Code
@@ -434,7 +434,7 @@ Sometimes it is desirable to pass more complex options to the server.  All metho
 	// Make sure to require this
 	import (
 		"github.com/riaken/riaken-core/rpb"
-		"code.google.com/p/goprotobuf/proto"
+		"github.com/golang/protobuf/proto"
 	)
 
 	// Code

--- a/bucket.go
+++ b/bucket.go
@@ -1,7 +1,7 @@
 package riaken_core
 
 import (
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/bucket_test.go
+++ b/bucket_test.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/counter.go
+++ b/counter.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"errors"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/counter_test.go
+++ b/counter_test.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/crdt.go
+++ b/crdt.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"errors"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/object.go
+++ b/object.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"errors"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/object_test.go
+++ b/object_test.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"testing"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/query.go
+++ b/query.go
@@ -3,7 +3,7 @@ package riaken_core
 import (
 	"errors"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/rpb.go
+++ b/rpb.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 

--- a/rpb/riak.pb.go
+++ b/rpb/riak.pb.go
@@ -4,7 +4,7 @@
 
 package rpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/rpb/riak_dt.pb.go
+++ b/rpb/riak_dt.pb.go
@@ -4,7 +4,7 @@
 
 package rpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/rpb/riak_kv.pb.go
+++ b/rpb/riak_kv.pb.go
@@ -4,7 +4,7 @@
 
 package rpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/rpb/riak_search.pb.go
+++ b/rpb/riak_search.pb.go
@@ -4,7 +4,7 @@
 
 package rpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/rpb/riak_yokozuna.pb.go
+++ b/rpb/riak_yokozuna.pb.go
@@ -4,7 +4,7 @@
 
 package rpb
 
-import proto "code.google.com/p/goprotobuf/proto"
+import proto "github.com/golang/protobuf/proto"
 import json "encoding/json"
 import math "math"
 

--- a/session.go
+++ b/session.go
@@ -10,7 +10,7 @@ import (
 	"net"
 	"syscall"
 
-	"code.google.com/p/goprotobuf/proto"
+	"github.com/golang/protobuf/proto"
 	"github.com/riaken/riaken-core/rpb"
 )
 


### PR DESCRIPTION
Changing all references of code.google.com/p/goprotobuf/proto to github.com/golang/protobuf/proto

https://groups.google.com/forum/#!searchin/golang-nuts/goprotobuf/golang-nuts/oXkI5cipsuI/PsRwLgbksocJ

And now they've officially removed the code from code.google.com . So every time you do go get you get an error:

$ go get github.com/riaken/riaken-core
package code.google.com/p/goprotobuf/proto: unable to detect version control system for code.google.com/ path

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/riaken/riaken-core/11)
<!-- Reviewable:end -->
